### PR TITLE
FGSM adversarial robustness of SPCA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.DS_Store
 B-Sparse\ PCA/
 Data_Mining_M2-projects.pdf
-*.txt
 figures/
+*.png

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ $$
 $$
 
 Where:
+
 - $X$: Input data matrix.
 - $W$: Principal components matrix.
 - $H$: Sparse loadings matrix.
@@ -30,96 +31,10 @@ Where:
 - $\beta$: Controls smoothness (L2 regularization).
 
 The algorithm alternates between:
+
 1. Fixing $H$ to optimize $W$.
 2. Fixing $W$ to optimize $H$ using Elastic Net regularization.
 
----
-
-## 🚀 Quickstart Guide
-
-### 1️⃣ Clone the Repository
-
-```bash
-git clone https://github.com/theodruilhe/Sparse_PCA.git
-cd Sparse_PCA
-```
-
-### 2️⃣ Install Dependencies
-
-Ensure you have Python installed along with the required libraries:
-
-```bash
-pip install -r requirements.txt
-```
-
-### 3️⃣ Run Sparse PCA
-
-Here's an example of how to use Sparse PCA on your dataset:
-
-```python
-import numpy as np
-from sparse_pca import SparsePCA
-
-# Load your dataset
-X = np.loadtxt('your_data_file.txt')
-
-# Initialize the Sparse PCA model
-model = SparsePCA(n_components=5, alpha=0.1, beta=0.1)
-
-# Fit the model
-model.fit(X)
-
-# Transform your data
-X_transformed = model.transform(X)
-
-# Get the components
-components = model.components_
-
-print("Sparse Components:", components)
-```
-
----
-
-## 📚 Documentation
-
-### Parameters
-- **`n_components`**: Number of principal components to compute.
-- **`alpha`**: Sparsity regularization parameter (L1 norm).
-- **`beta`**: Ridge regularization parameter (L2 norm).
-
-### Outputs
-- **`components_`**: Sparse principal components.
-- **`explained_variance_`**: Variance explained by each component.
-
----
-
-## 📊 Example Use Case
-
-Suppose you have a high-dimensional dataset with 1,000 features, and you suspect that only a handful of these features are relevant. Using Sparse PCA, you can:
-1. Reduce the dataset's dimensionality.
-2. Identify the most critical features for your problem.
-
----
-
-## 📝 References
+## References
 
 - Zou, H., Hastie, T., & Tibshirani, R. (2006). Sparse Principal Component Analysis. *Journal of Computational and Graphical Statistics*, 15(2), 265-286.
-- Jenatton, R., Obozinski, G., & Bach, F. (2009). Structured Sparse Principal Component Analysis. [arXiv preprint](https://arxiv.org/abs/0909.1440).
-
----
-
-## 💻 Contributions
-
-We welcome contributions to this project! Please fork the repository and submit a pull request for any enhancements or bug fixes.
-
----
-
-## 📜 License
-
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
-
----
-
-## 🙌 Acknowledgements
-
-Special thanks to the creators of Sparse PCA algorithms and the open-source community for their invaluable contributions to data science.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy>=1.19.2
+scikit-learn>=0.24.2
+torch>=1.9.0
+adversarial-robustness-toolbox>=1.9.0
+matplotlib>=3.3.4
+opencv-python>=4.5.3
+pandas>=1.3.0

--- a/scripts/fgsm_features.py
+++ b/scripts/fgsm_features.py
@@ -1,0 +1,217 @@
+import numpy as np
+from sklearn.datasets import fetch_openml
+from sklearn.preprocessing import StandardScaler
+from sklearn.model_selection import train_test_split
+from sklearn.decomposition import PCA, SparsePCA
+from sklearn.svm import SVC
+from art.attacks.evasion import FastGradientMethod, ProjectedGradientDescent
+from art.estimators.classification import SklearnClassifier
+import matplotlib.pyplot as plt
+from tqdm import tqdm
+
+"""
+Sources about spca and robustness:
+- https://arxiv.org/abs/2011.06585
+- https://proceedings.mlr.press/v125/awasthi20a.html
+- https://arxiv.org/abs/2411.05332  
+"""
+
+def setup_classifier(X_train, y_train):
+    # Initialize and train an SVM classifier with adjusted parameters
+    svm = SVC(kernel='rbf', probability=True, C=1.0, gamma='scale')
+    svm.fit(X_train, y_train)
+    
+    # Wrap the sklearn classifier for ART with proper scaling
+    classifier = SklearnClassifier(
+        model=svm,
+        clip_values=(0, 1),
+        preprocessing_defences=None,
+        postprocessing_defences=None,
+        preprocessing=(0, 1)
+    )
+    return classifier
+
+def load_mnist(n_samples=None):
+    print("Fetching MNIST dataset...")
+    X, y = fetch_openml('mnist_784', version=1, return_X_y=True, as_frame=False)
+    print("Scaling and splitting data...")
+    # Take a smaller subset for testing
+    if n_samples is None:
+        n_samples = len(X)
+    random_indices = np.random.choice(len(X), n_samples, replace=False)
+    X = X[random_indices]
+    y = y[random_indices].astype(np.int32)  # Convert labels to int32
+    
+    # Scale data to [0,1] range
+    X = X / 255.0
+    
+    # Split the data
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=29)
+    return X_train, X_test, y_train, y_test
+
+def generate_adversarial_samples(classifier, X, method='FGSM', eps=0.3):
+    if method == 'FGSM':
+        attack = FastGradientMethod(classifier, eps=eps, batch_size=128)
+    elif method == 'PGD':
+        attack = ProjectedGradientDescent(classifier, eps=eps, batch_size=128)
+    
+    # Generate adversarial samples in batches to avoid memory issues
+    X_adv = attack.generate(x=X)
+    
+    # Ensure the adversarial samples are within valid range
+    X_adv = np.clip(X_adv, 0, 1)
+    return X_adv
+
+def evaluate_robustness(X_clean, X_adv, y, classifier):
+    # Classification accuracy
+    clean_predictions = classifier.predict(X_clean)
+    adv_predictions = classifier.predict(X_adv)
+    
+    # Convert predictions to class labels by taking argmax
+    clean_predictions = np.argmax(clean_predictions, axis=1)
+    adv_predictions = np.argmax(adv_predictions, axis=1)
+    
+    # Convert string labels to integers if needed
+    y = y.astype(int)
+    clean_predictions = clean_predictions.astype(int)
+    adv_predictions = adv_predictions.astype(int)
+    
+    clean_accuracy = np.mean(clean_predictions == y) * 100
+    adv_accuracy = np.mean(adv_predictions == y) * 100
+    
+    return clean_accuracy, adv_accuracy
+
+def benchmark_robustness(X_test_pca_dict, X_test_spca_dict, y_test, classifier_pca_dict, classifier_spca_dict, eps_list):
+    # Get clean accuracies first (epsilon = 0)
+    pca_clean_acc_dict = {}
+    spca_clean_acc_dict = {}
+    
+    for n_comp in X_test_pca_dict.keys():
+        pca_clean_acc, _ = evaluate_robustness(X_test_pca_dict[n_comp], X_test_pca_dict[n_comp], y_test, classifier_pca_dict[n_comp])
+        spca_clean_acc, _ = evaluate_robustness(X_test_spca_dict[n_comp], X_test_spca_dict[n_comp], y_test, classifier_spca_dict[n_comp])
+        pca_clean_acc_dict[n_comp] = pca_clean_acc
+        spca_clean_acc_dict[n_comp] = spca_clean_acc
+    
+    # Initialize lists to store accuracies
+    pca_accuracies_dict = {n_comp: [acc] for n_comp, acc in pca_clean_acc_dict.items()}
+    spca_accuracies_dict = {n_comp: [acc] for n_comp, acc in spca_clean_acc_dict.items()}
+    
+    # Test different epsilon values
+    pbar = tqdm(total=len(eps_list) * len(X_test_pca_dict.keys()), desc='Testing epsilon values')
+    for eps in eps_list:
+        for n_comp in X_test_pca_dict.keys():
+            pbar.set_description(f'Testing epsilon={eps}, n_comp={n_comp}')
+            # Generate adversarial samples for both methods
+            X_test_pca_adv = generate_adversarial_samples(classifier_pca_dict[n_comp], X_test_pca_dict[n_comp], method='FGSM', eps=eps)
+            X_test_spca_adv = generate_adversarial_samples(classifier_spca_dict[n_comp], X_test_spca_dict[n_comp], method='FGSM', eps=eps)
+            
+            # Evaluate robustness
+            _, pca_adv_acc = evaluate_robustness(X_test_pca_dict[n_comp], X_test_pca_adv, y_test, classifier_pca_dict[n_comp])
+            _, spca_adv_acc = evaluate_robustness(X_test_spca_dict[n_comp], X_test_spca_adv, y_test, classifier_spca_dict[n_comp])
+            
+            pca_accuracies_dict[n_comp].append(pca_adv_acc)
+            spca_accuracies_dict[n_comp].append(spca_adv_acc)
+            pbar.update(1)
+    pbar.close()
+    
+    return np.concatenate(([0], eps_list)), pca_accuracies_dict, spca_accuracies_dict
+
+def main(eps_list, n_components_list, n_samples):
+    # Load and preprocess data
+    print("Loading MNIST dataset...")
+    X_train, X_test, y_train, y_test = load_mnist(n_samples=n_samples)
+    
+    # Scale data to [0,1] range for adversarial attacks
+    X_train = (X_train - X_train.min()) / (X_train.max() - X_train.min())
+    X_test = (X_test - X_test.min()) / (X_test.max() - X_test.min())
+    
+    print("Initializing and fitting dimensionality reduction methods...")
+    
+    # Dictionaries to store transformed data and classifiers
+    X_train_pca_dict = {}
+    X_test_pca_dict = {}
+    X_train_spca_dict = {}
+    X_test_spca_dict = {}
+    classifier_pca_dict = {}
+    classifier_spca_dict = {}
+    
+    for n_comp in tqdm(n_components_list):
+        # Initialize and fit PCA and SPCA
+        pca = PCA(n_components=n_comp)
+        sparse_pca = SparsePCA(n_components=n_comp, random_state=29, max_iter=100, alpha=1.0)
+        
+        # Fit transformations
+        pca.fit(X_train)
+        sparse_pca.fit(X_train)
+        
+        # Transform data
+        X_train_pca = pca.transform(X_train)
+        X_test_pca = pca.transform(X_test)
+        X_train_spca = sparse_pca.transform(X_train)
+        X_test_spca = sparse_pca.transform(X_test)
+        
+        # Normalize transformed data
+        scaler = StandardScaler()
+        X_train_pca = scaler.fit_transform(X_train_pca)
+        X_test_pca = scaler.transform(X_test_pca)
+        X_train_spca = scaler.fit_transform(X_train_spca)
+        X_test_spca = scaler.transform(X_test_spca)
+        
+        # Store transformed data
+        X_train_pca_dict[n_comp] = X_train_pca
+        X_test_pca_dict[n_comp] = X_test_pca
+        X_train_spca_dict[n_comp] = X_train_spca
+        X_test_spca_dict[n_comp] = X_test_spca
+        
+        # Setup classifiers
+        classifier_pca_dict[n_comp] = setup_classifier(X_train_pca, y_train)
+        classifier_spca_dict[n_comp] = setup_classifier(X_train_spca, y_train)
+    
+    # Run benchmark tests
+    print("Running benchmark tests...")
+    epsilons, pca_accuracies_dict, spca_accuracies_dict = benchmark_robustness(
+        X_test_pca_dict, X_test_spca_dict, y_test, classifier_pca_dict, classifier_spca_dict, eps_list
+    )
+    # Print final results
+    print("\nBenchmark Results:")
+    print("Epsilon values:", epsilons)
+    for n_comp in n_components_list:
+        print(f"\nResults for {n_comp} components:")
+        print(f"PCA accuracies: {pca_accuracies_dict[n_comp]}")
+        print(f"SPCA accuracies: {spca_accuracies_dict[n_comp]}")
+    
+    # Create and save the plot with enhanced visualization
+    fig, ax = plt.subplots(figsize=(12, 8))
+    
+    # Create a colormap
+    cmap = plt.cm.viridis
+    norm = plt.Normalize(min(n_components_list), max(n_components_list))
+    
+    # Plot lines for each number of components
+    for n_comp in n_components_list:
+        color = cmap(norm(n_comp))
+        # Plot PCA (dashed lines)
+        ax.plot(epsilons, pca_accuracies_dict[n_comp], '--o', color=color, label=f'PCA ({n_comp} components)')
+        # Plot SPCA (solid lines)
+        ax.plot(epsilons, spca_accuracies_dict[n_comp], '-o', color=color, label=f'SPCA ({n_comp} components)')
+    
+    ax.set_xlabel('Epsilon (ε)')
+    ax.set_ylabel('Accuracy (%)')
+    ax.set_title('Model Accuracy vs. Adversarial Attack Strength (FGSM)')
+    
+    # Add colorbar
+    sm = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+    sm.set_array([])
+    plt.colorbar(sm, ax=ax, label='Number of Components')
+    
+    # Add legend
+    ax.legend()
+    ax.grid(True)
+    plt.savefig('robustness_comparison.png')
+    plt.show()
+
+if __name__ == "__main__":
+    n_components_list = [20, 50, 100, 150, 191] # 191 = 95% of cumulative explained variance
+    eps_list = np.arange(0.1, 1.0, 0.1)
+    n_samples = 5000
+    main(eps_list, n_components_list, n_samples)

--- a/scripts/fgsm_images.py
+++ b/scripts/fgsm_images.py
@@ -1,0 +1,451 @@
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from art.attacks.evasion import FastGradientMethod, ProjectedGradientDescent
+from art.estimators.classification import PyTorchClassifier
+from sklearn.datasets import fetch_openml
+from sklearn.decomposition import PCA, SparsePCA
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+from tqdm import tqdm
+
+"""
+Sources about spca and robustness:
+- https://arxiv.org/abs/2011.06585
+- https://proceedings.mlr.press/v125/awasthi20a.html
+- https://arxiv.org/abs/2411.05332  
+"""
+
+
+def load_mnist(n_samples=None):
+    print("Fetching MNIST dataset...")
+    X, y = fetch_openml("mnist_784", version=1, return_X_y=True, as_frame=False)
+    print("Scaling and splitting data...")
+    if n_samples is None:
+        n_samples = len(X)
+    random_indices = np.random.choice(len(X), n_samples, replace=False)
+    X = X[random_indices]
+    y = y[random_indices].astype(np.int32)
+
+    X = X / 255.0
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=29
+    )
+    return X_train, X_test, y_train, y_test, n_samples
+
+
+class FixedLinear(nn.Module):
+    """
+    Implements a fixed linear transform using precomputed weights and bias.
+    This is used to apply the PCA or SPCA transformation.
+    """
+
+    def __init__(self, weight, bias):
+        super(FixedLinear, self).__init__()
+        in_features = weight.shape[1]
+        out_features = weight.shape[0]
+        self.linear = nn.Linear(in_features, out_features, bias=True)
+        with torch.no_grad():
+            self.linear.weight.copy_(weight)
+            self.linear.bias.copy_(bias)
+        # Freeze parameters
+        for param in self.linear.parameters():
+            param.requires_grad = False
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class FixedScaler(nn.Module):
+    """
+    Implements a fixed StandardScaler: (x - mean) / scale.
+    """
+
+    def __init__(self, mean, scale):
+        super(FixedScaler, self).__init__()
+        # Register buffers so they move with the model but are not trained.
+        self.register_buffer("mean", torch.tensor(mean, dtype=torch.float32))
+        self.register_buffer("scale", torch.tensor(scale, dtype=torch.float32))
+
+    def forward(self, x):
+        return (x - self.mean) / self.scale
+
+
+class ClassifierNN(nn.Module):
+    """
+    A simple two-layer neural network classifier.
+    """
+
+    def __init__(self, input_dim, num_classes=10):
+        super(ClassifierNN, self).__init__()
+        self.fc1 = nn.Linear(input_dim, 128)
+        self.fc2 = nn.Linear(128, num_classes)
+
+    def forward(self, x):
+        x = F.relu(self.fc1(x))
+        x = self.fc2(x)
+        return x
+
+
+class PipelineModel(nn.Module):
+    """
+    This model takes raw (flattened) images, applies a fixed PCA/SPCA transformation,
+    then fixed scaling, and finally a trainable neural network classifier.
+    """
+
+    def __init__(self, fixed_transform, fixed_scaler, classifier):
+        super(PipelineModel, self).__init__()
+        self.fixed_transform = fixed_transform  # PCA or SPCA layer
+        self.fixed_scaler = fixed_scaler  # Scaler layer
+        self.classifier = classifier  # Trainable NN classifier
+
+    def forward(self, x):
+        x = self.fixed_transform(x)
+        x = self.fixed_scaler(x)
+        x = self.classifier(x)
+        return x
+
+
+def train_pipeline_model(
+    model, X_train, y_train, device, num_epochs=10, batch_size=128, verbose=False
+):
+    model.train()
+    optimizer = optim.Adam(model.parameters(), lr=0.001)
+    criterion = nn.CrossEntropyLoss()
+
+    dataset = torch.utils.data.TensorDataset(
+        torch.tensor(X_train, dtype=torch.float32),
+        torch.tensor(y_train, dtype=torch.long),
+    )
+    loader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
+    for epoch in range(1, num_epochs + 1):
+        epoch_loss = 0.0
+        for batch_X, batch_y in loader:
+            batch_X, batch_y = batch_X.to(device), batch_y.to(device)
+            optimizer.zero_grad()
+            outputs = model(batch_X)
+            loss = criterion(outputs, batch_y)
+            loss.backward()
+            optimizer.step()
+            epoch_loss += loss.item() * batch_X.size(0)
+        avg_loss = epoch_loss / len(loader.dataset)
+        if verbose:
+            print(f"Epoch {epoch}: Loss {avg_loss:.4f}")
+    return model, optimizer, criterion
+
+
+def setup_pipeline_classifier(
+    transformer, X_train, y_train, device=torch.device("cpu"), num_epochs=20
+):
+    """
+    Given a transformer (PCA or SparsePCA) and raw training data,
+    fit the transformer and a StandardScaler on the transformed data,
+    then build a composite PyTorch model that applies the fixed transformation,
+    scaling, and a small NN classifier.
+    The model is trained and wrapped with ART's PyTorchClassifier.
+    """
+    transformer.fit(X_train)
+    X_train_trans = transformer.transform(X_train)
+
+    scaler = StandardScaler()
+    X_train_scaled = scaler.fit_transform(X_train_trans)
+
+    n_comp = X_train_trans.shape[1]
+
+    # For PCA, transformer.mean_ exists; for SparsePCA, it may not.
+    if hasattr(transformer, "mean_"):
+        mean_val = transformer.mean_
+    else:
+        mean_val = np.zeros(X_train.shape[1])  # No centering for SparsePCA
+
+    # Compute fixed transform parameters.
+    # The transformation is: (x - mean) dot components_.T.
+    # Thus, weight = transformer.components_ and bias = - (mean dot components_.T)
+    weight = torch.tensor(transformer.components_, dtype=torch.float32)
+    bias = -torch.matmul(
+        torch.tensor(mean_val, dtype=torch.float32),
+        torch.tensor(transformer.components_.T, dtype=torch.float32),
+    )
+
+    fixed_transform = FixedLinear(weight, bias)
+    fixed_scaler = FixedScaler(scaler.mean_, scaler.scale_)
+
+    classifier_nn = ClassifierNN(input_dim=n_comp, num_classes=10)
+    model = PipelineModel(fixed_transform, fixed_scaler, classifier_nn).to(device)
+
+    model, optimizer, criterion = train_pipeline_model(
+        model, X_train, y_train, device, num_epochs=num_epochs, verbose=False
+    )
+
+    art_classifier = PyTorchClassifier(
+        model=model,
+        loss=criterion,
+        optimizer=optimizer,
+        input_shape=(784,),
+        nb_classes=10,
+        clip_values=(0, 1),
+    )
+    return art_classifier
+
+
+def generate_adversarial_samples(classifier, X, method="FGSM", eps=0.3):
+    if method == "FGSM":
+        attack = FastGradientMethod(classifier, eps=eps, batch_size=128)
+    elif method == "PGD":
+        attack = ProjectedGradientDescent(classifier, eps=eps, batch_size=128)
+    else:
+        raise ValueError(f"Invalid attack method: {method}")
+
+    X_adv = attack.generate(x=X)
+    X_adv = np.clip(X_adv, 0, 1)
+    return X_adv
+
+
+def evaluate_robustness(X_clean, X_adv, y, classifier):
+    clean_predictions = classifier.predict(X_clean)
+    adv_predictions = classifier.predict(X_adv)
+
+    clean_predictions = np.argmax(clean_predictions, axis=1)
+    adv_predictions = np.argmax(adv_predictions, axis=1)
+
+    y = y.astype(int)
+    clean_predictions = clean_predictions.astype(int)
+    adv_predictions = adv_predictions.astype(int)
+
+    clean_accuracy = np.mean(clean_predictions == y) * 100
+    adv_accuracy = np.mean(adv_predictions == y) * 100
+
+    return clean_accuracy, adv_accuracy
+
+
+def benchmark_robustness(
+    X_test,
+    y_test,
+    classifier_pca_dict,
+    classifier_spca_dict,
+    eps_list,
+    n_samples,
+    save_samples=True,
+):
+    pca_clean_acc_dict = {}
+    spca_clean_acc_dict = {}
+
+    for n_comp in classifier_pca_dict.keys():
+        pca_clean_acc, _ = evaluate_robustness(
+            X_test, X_test, y_test, classifier_pca_dict[n_comp]
+        )
+        spca_clean_acc, _ = evaluate_robustness(
+            X_test, X_test, y_test, classifier_spca_dict[n_comp]
+        )
+        pca_clean_acc_dict[n_comp] = pca_clean_acc
+        spca_clean_acc_dict[n_comp] = spca_clean_acc
+
+    pca_accuracies_dict = {n_comp: [acc] for n_comp, acc in pca_clean_acc_dict.items()}
+    spca_accuracies_dict = {
+        n_comp: [acc] for n_comp, acc in spca_clean_acc_dict.items()
+    }
+
+    pbar = tqdm(
+        total=len(eps_list) * len(classifier_pca_dict.keys()),
+        desc="Testing epsilon values",
+    )
+
+    if save_samples:
+        n_components_list = list(classifier_pca_dict.keys())
+        X_adv_pcas = {}
+        X_adv_spcas = {}
+
+    for n_comp in classifier_pca_dict.keys():
+        if save_samples:
+            X_adv_pcas[n_comp] = []
+            X_adv_spcas[n_comp] = []
+        for eps in eps_list:
+            pbar.set_description(f"Testing epsilon={eps}, n_comp={n_comp}")
+            X_adv_pca = generate_adversarial_samples(
+                classifier_pca_dict[n_comp], X_test, method="FGSM", eps=eps
+            )
+            X_adv_spca = generate_adversarial_samples(
+                classifier_spca_dict[n_comp], X_test, method="FGSM", eps=eps
+            )
+
+            _, pca_adv_acc = evaluate_robustness(
+                X_test, X_adv_pca, y_test, classifier_pca_dict[n_comp]
+            )
+            _, spca_adv_acc = evaluate_robustness(
+                X_test, X_adv_spca, y_test, classifier_spca_dict[n_comp]
+            )
+
+            pca_accuracies_dict[n_comp].append(pca_adv_acc)
+            spca_accuracies_dict[n_comp].append(spca_adv_acc)
+
+            if save_samples:
+                X_adv_pcas[n_comp].append(X_adv_pca[0])
+                X_adv_spcas[n_comp].append(X_adv_spca[0])
+
+            pbar.update(1)
+    pbar.close()
+    if save_samples:
+        n_components_list = list(classifier_pca_dict.keys())
+        directory = f"adv_samples_eps_{eps_list[0]}_to_{eps_list[-1]}_ncomp_{min(n_components_list)}_to_{max(n_components_list)}_nsamples_{n_samples}"
+        os.makedirs(directory, exist_ok=True)
+        X_image = X_test[0]
+        for ncp in n_components_list:
+            show_adversarial_samples(
+                X_image, X_adv_pcas[ncp], X_adv_spcas[ncp], eps_list, ncp, directory
+            )
+
+    return np.concatenate(([0], eps_list)), pca_accuracies_dict, spca_accuracies_dict
+
+
+def plot_benchmark(
+    epsilons, pca_accuracies_dict, spca_accuracies_dict, n_components_list, n_samples
+):
+    fig, ax = plt.subplots(figsize=(12, 8))
+    cmap = plt.cm.viridis
+    norm = plt.Normalize(min(n_components_list), max(n_components_list))
+
+    for n_comp in n_components_list:
+        color = cmap(norm(n_comp))
+        ax.plot(
+            epsilons,
+            pca_accuracies_dict[n_comp],
+            "--o",
+            color=color,
+            label="PCA" if n_comp == n_components_list[0] else "_nolegend_",
+        )
+        ax.plot(
+            epsilons,
+            spca_accuracies_dict[n_comp],
+            "-o",
+            color=color,
+            label="SPCA" if n_comp == n_components_list[0] else "_nolegend_",
+        )
+
+    ax.set_xlabel("Epsilon (ε)")
+    ax.set_ylabel("Accuracy (%)")
+    ax.set_title("Model Accuracy vs. Adversarial Attack Strength (FGSM)")
+    sm = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+    sm.set_array([])
+    plt.colorbar(sm, ax=ax, label="Number of Components")
+    ax.legend()
+    ax.grid(True)
+    plt.savefig(
+        f"fgsm_epsilons_{epsilons[1]}_to_{epsilons[-1]}_ncomp_{min(n_components_list)}_to_{max(n_components_list)}_nsamples_{n_samples}.png",
+        dpi=300,
+    )
+
+
+def show_adversarial_samples(X, X_adv_pcas, X_adv_spcas, eps_list, ncp, directory):
+    """
+    Show original image and its adversarial counterparts side by side for different epsilon.
+    """
+    n_eps = len(X_adv_pcas)
+    fig, axes = plt.subplots(2, n_eps + 1, figsize=(15, 6))
+    # Plot original image
+    axes[0, 0].imshow(X.reshape(28, 28), cmap="gray")
+    axes[0, 0].axis("off")
+    axes[0, 0].set_title("Original Image")
+    axes[1, 0].imshow(X.reshape(28, 28), cmap="gray")
+    axes[1, 0].axis("off")
+    axes[1, 0].set_title("Original Image")
+    for i, (X_adv_pca, X_adv_spca) in enumerate(zip(X_adv_pcas, X_adv_spcas)):
+        axes[0, i + 1].imshow(X_adv_pca.reshape(28, 28), cmap="gray")
+        axes[0, i + 1].axis("off")
+        axes[0, i + 1].set_title(f"ε={eps_list[i]:.2f}")
+        axes[1, i + 1].imshow(X_adv_spca.reshape(28, 28), cmap="gray")
+        axes[1, i + 1].axis("off")
+        axes[1, i + 1].set_title(f"ε={eps_list[i]:.2f}")
+    axes[0, 0].set_ylabel("PCA")
+    axes[1, 0].set_ylabel("SPCA")
+    plt.tight_layout()
+    plt.savefig(
+        f"{directory}/adversarial_samples_{eps_list[0]:.2f}_to_{eps_list[-1]:.2f}_{ncp}.png",
+        dpi=300,
+    )
+
+
+def main(eps_list, n_components_list, n_samples, save_samples=True):
+    X_train, X_test, y_train, y_test, n_samples = load_mnist(n_samples=n_samples)
+
+    X_train = ((X_train - X_train.min()) / (X_train.max() - X_train.min())).astype(
+        np.float32
+    )
+    X_test = ((X_test - X_test.min()) / (X_test.max() - X_test.min())).astype(
+        np.float32
+    )
+
+    # Set device for PyTorch (use GPU if available)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    print("Initializing and training PCA and SPCA pipeline models...")
+    classifier_pca_dict = {}
+    classifier_spca_dict = {}
+
+    for n_comp in tqdm(n_components_list):
+        pca_transformer = PCA(n_components=n_comp)
+        spca_transformer = SparsePCA(
+            n_components=n_comp, random_state=29, max_iter=100, alpha=1
+        )
+
+        classifier_pca_dict[n_comp] = setup_pipeline_classifier(
+            pca_transformer, X_train, y_train, device=device, num_epochs=20
+        )
+        classifier_spca_dict[n_comp] = setup_pipeline_classifier(
+            spca_transformer, X_train, y_train, device=device, num_epochs=20
+        )
+
+    print("Running benchmark tests...")
+    epsilons, pca_accuracies_dict, spca_accuracies_dict = benchmark_robustness(
+        X_test,
+        y_test,
+        classifier_pca_dict,
+        classifier_spca_dict,
+        eps_list,
+        n_samples,
+        save_samples=save_samples,
+    )
+
+    print("\nBenchmark Results:")
+    print("Epsilon values:", [round(i, 2) for i in epsilons])
+    for n_comp in n_components_list:
+        print(f"\nResults for {n_comp} components:")
+        print(f"PCA accuracies: {[round(i, 2) for i in pca_accuracies_dict[n_comp]]}")
+        print(f"SPCA accuracies: {[round(i, 2) for i in spca_accuracies_dict[n_comp]]}")
+
+    plot_benchmark(
+        epsilons,
+        pca_accuracies_dict,
+        spca_accuracies_dict,
+        n_components_list,
+        n_samples,
+    )
+
+
+def unit_test_benchmark():
+    eps_list = np.arange(0.1, 1.0, 0.1)
+    n_components_list = [150, 191]
+    main(eps_list, n_components_list, 1000, save_samples=True)
+
+
+if __name__ == "__main__":
+    test_mode = False
+    if test_mode:
+        unit_test_benchmark()
+        exit()
+    n_components_list = [
+        20,
+        50,
+        100,
+        150,
+        191,
+    ]  # 191 approximates 95% cumulative explained variance
+    eps_list = np.arange(0.05, 0.55, 0.05)
+    n_samples = None
+    main(eps_list, n_components_list, n_samples, save_samples=True)


### PR DESCRIPTION
## Are features from SPCA more robust to adversarial attacks?

This pull request tries to answer this by testing FGSM attacks on MNIST digits with a simple MLP classifier, using a layer of PCA and SPCA features extraction to compare, with the script `scripts/fgsm_images.py`. The script `scripts/fgsm_features.py` runs the fgsm attacks on features instead of running it on images, and uses a SVM as the classifier.

Install the dependencies from the `requirements.txt` file with `pip install -r requirements.txt`.